### PR TITLE
Utilization of local piral-cli (instead of global installation)

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -7,34 +7,34 @@ import { resolve } from 'path';
 export function registerCommands(context: vscode.ExtensionContext, refreshCommands: () => void, refreshWorkspace: () => void) {
   context.subscriptions.push(
     vscode.commands.registerCommand('vscode-piral.cli.pilet.debug', () => {
-      runCommand('pilet debug', RepoType.Pilet);
+      runCommand('npx pilet debug', RepoType.Pilet);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.pilet.build', () => {
-      runCommand('pilet build', RepoType.Pilet);
+      runCommand('npx  pilet build', RepoType.Pilet);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.pilet.publish', () => {
-      runCommand('pilet publish', RepoType.Pilet);
+      runCommand('npx pilet publish', RepoType.Pilet);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.pilet.validate', () => {
-      runCommand('pilet validate', RepoType.Pilet);
+      runCommand('npx pilet validate', RepoType.Pilet);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.piral.debug', () => {
-      runCommand('piral debug', RepoType.Piral);
+      runCommand('npx piral debug', RepoType.Piral);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.piral.build', () => {
-      runCommand('piral build', RepoType.Piral);
+      runCommand('npx piral build', RepoType.Piral);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.piral.build.emulator', () => {
-      runCommand('piral build --type emulator', RepoType.Piral);
+      runCommand('npx piral build --type emulator', RepoType.Piral);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.piral.build.release', () => {
-      runCommand('piral build --type release', RepoType.Piral);
+      runCommand('npx piral build --type release', RepoType.Piral);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.piral.declaration', () => {
-      runCommand('piral declaration', RepoType.Piral);
+      runCommand('npx piral declaration', RepoType.Piral);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.piral.validate', () => {
-      runCommand('piral validate', RepoType.Piral);
+      runCommand('npx piral validate', RepoType.Piral);
     }),
     vscode.commands.registerCommand('vscode-piral.cli.available-commands.refreshEntry', refreshCommands),
     vscode.commands.registerCommand('vscode-piral.cli.workspace-info.refreshEntry', refreshWorkspace),

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -87,7 +87,7 @@ function detectNpm(root: string) {
 }
 
 function detectYarn(root: string) {
-  return !!(existsSync(`${root}/yarn.lock`));
+  return !!existsSync(`${root}/yarn.lock`);
 }
 
 function detectPnpm(root: string) {
@@ -101,13 +101,13 @@ function detectPnpm(root: string) {
 async function installDependencies(root: string) {
   const [hasNpm, hasYarn, hasPnpm] = await Promise.all([detectNpm(root), detectYarn(root), detectPnpm(root)]);
   if (!hasNpm && !hasYarn && !hasPnpm) {
-    execCommand('npx lerna bootstrap')
+    execCommand('npx lerna bootstrap');
   } else if (hasNpm) {
-    execCommand('npm install')
+    execCommand('npm install');
   } else if (hasYarn) {
-    execCommand('yarn install')
+    execCommand('yarn install');
   } else if (hasPnpm) {
-    execCommand('pnpm install')
+    execCommand('pnpm install');
   }
 }
 
@@ -148,7 +148,7 @@ export function runCommand(cmd: string, requiredRepoType = RepoType.Undefined) {
         )
         .then((answer) => {
           if (answer === 'Yes') {
-            installDependencies(workspace.uri.fsPath)
+            installDependencies(workspace.uri.fsPath);
           }
         });
     } else {

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -90,7 +90,7 @@ function detectPnpm(root: string) {
   });
 }
 
-function detectlerna(root: string) {
+function detectLerna(root: string) {
   return new Promise((res) => {
     access(resolve(root, 'lerna.json'), constants.F_OK, (noPackageLock) => {
       res(!noPackageLock);
@@ -99,7 +99,7 @@ function detectlerna(root: string) {
 }
 
 async function installDependencies(root: string) {
-  const [hasYarn, hasPnpm, hasLerna] = await Promise.all([detectYarn(root), detectPnpm(root), detectlerna(root)]);
+  const [hasYarn, hasPnpm, hasLerna] = await Promise.all([detectYarn(root), detectPnpm(root), detectLerna(root)]);
   if (hasLerna) {
     execCommand('npx lerna bootstrap');
   } else if (hasYarn) {


### PR DESCRIPTION
Added validation before executing the commands for:
-    `node-modules`
-    `piral` or  `pilet` in `node-modules/.bin` 

If they are not available then the user gets asked if he wants us to download the dependencies. In case 'Yes' the dependencies will be installed then he will be able to run and execute the available commands.

Changed the commands formats and added npx e.g: `pilet debug`  -> `npx pilet debug`

![Screenshot 2022-04-13 180214](https://user-images.githubusercontent.com/55950527/163222591-643a073a-56cb-456c-aec7-38fb189de5f0.png)

![Screenshot 2022-04-13 180316](https://user-images.githubusercontent.com/55950527/163222596-72a2c9cd-fbc1-46c0-9baf-f304ec02ba0c.png)
